### PR TITLE
PTC flats change; plot updates

### DIFF
--- a/cmost_camera.py
+++ b/cmost_camera.py
@@ -314,12 +314,12 @@ def standard_analysis_exposures(camid, detid, config_filepath, ledw='None', sing
                         # Min-length exposures
                         cam.set_basename(basename+'_flat_'+g+'_'+str(voltage))
                         cam.key('EXPTIME=0//exposure time in seconds')
-                        cam.expose(0,2,0)
+                        cam.expose(0,3,0)
                         # Loop through exposure times
                         # Two exposures per exposure time for PTC generation
                         for t in np.rint(np.logspace(0,2.1,10)):
                             cam.key('EXPTIME='+str(int(t))+'//exposure time in seconds')
-                            cam.expose(int(t),2,0)
+                            cam.expose(int(t),3,0)
                         print('Time elapsed: '+str(time.time() - start)+' s')
                     
                     # Get temperature again

--- a/cmost_exposure.py
+++ b/cmost_exposure.py
@@ -113,18 +113,18 @@ class Exposure():
         A Numpy array of 2-d frames, containing CDS frames that have been binned up by a factor supplied
         by the user (default 4)
     '''
-    def __init__(self, filepath='', custom_keys=[], subframe=None, cleanup=True, graycode=False):
+    def __init__(self, filepath='', custom_keys=[], subframe=None, cleanup=True, graycode=False, ignore_frame=0):
         self.filepath = filepath
     
         if self.filepath != '':
             # Read image at provided filepath
-            self.read_fits(self.filepath, custom_keys, graycode, subframe)
+            self.read_fits(self.filepath, custom_keys, graycode, subframe, ignore_frame)
         
         # Once everything is loaded delete what's no longer needed
         if cleanup:
             self.cleanup_frames()
 
-    def read_fits(self, filepath, custom_keys, graycode, subframe):
+    def read_fits(self, filepath, custom_keys, graycode, subframe, ignore_frame):
         '''
         Read FITS image and populate attributes
         
@@ -185,6 +185,10 @@ class Exposure():
             else:
                 # Just ignore 0th Extension
                 ignore_ext = 1
+            
+            # Have we specified ignoring an actual data frame? Add that to the number of ignored extensions
+            # This will ignore frames from the beginning onwards
+            ignore_ext += ignore_frame
         else:
             # Image is stored in the 0th Extension
             # For frames not taken directly from the camera


### PR DESCRIPTION
Changes the PTC acquisition code to take 3 flats per voltage/exposure time setting, for now while the persistence issue is present.

Added to Exposure() the ability to ignore a specified number of initial frames, which is now used in the PTC analysis code to ignore the first flat frame taken (if the number of frames is 3).

Also reorders the bias and noise plots to be grouped by type, and all gains are now displayed in the order: low, low (dual), high, high (dual). Addresses #24.

Includes some tweaks to potentially make the histograms more useful as in #25.