### PR TITLE
Standard analysis update

### DIFF
--- a/cmost_analysis.py
+++ b/cmost_analysis.py
@@ -894,6 +894,7 @@ def standard_analysis_products(dirname, **kwargs):
     gain_color = {'high (dual-gain)': 'tab:blue', 'low (dual-gain)': 'tab:orange', 'high': 'tab:green', 'low': 'tab:red'}
     gain_line_color = {'high (dual-gain)': 'darkblue', 'low (dual-gain)': 'brown', 'high': 'darkgreen', 'low': 'darkred'}
     bad_pixel_colors = ['white', 'red', 'blue', 'limegreen','yellow']
+    bad_pixel_labels = ['Good', 'High Noise', 'High Dark', 'Bad Linearity', 'Bad Q.E.']
     
     # Initialize report document
     #doc_name = f'analysis_report_test.pdf'
@@ -958,8 +959,8 @@ def standard_analysis_products(dirname, **kwargs):
             for i in range(len(nw_types)):
                 plot_pixel_map[nw_pixel_map[i] > 0] = i+1.5
             plt.imshow(plot_pixel_map, cmap=bad_color_map, vmin=0, vmax=len(nw_types)+1, interpolation='none')
-            plt.colorbar(orientation='horizontal', label='Bad pixel type', ticks=[0.5,1.5,2.5,3.5,4.5],
-                         format=mticker.FixedFormatter(['Good', 'High Noise', 'High Dark', 'Bad Linearity', 'Bad Q.E.']))
+            plt.colorbar(orientation='horizontal', label='Bad pixel type', ticks=np.arange(nw_types+1)+0.5,
+                         format=mticker.FixedFormatter(bad_pixel_labels[:len(nw_types)+1]))
             
             # Get combined numbers and percentages of bad pixels
             summary_text = ''
@@ -997,8 +998,8 @@ def standard_analysis_products(dirname, **kwargs):
             for i in range(len(nr_types)):
                 plot_pixel_map[nr_pixel_map[i] > 0] = i+1.5
             plt.imshow(plot_pixel_map, cmap=bad_color_map, vmin=0, vmax=len(nr_types)+1, interpolation='none')
-            plt.colorbar(orientation='horizontal', label='Bad pixel type', ticks=[0.5,1.5,2.5],
-                         format=mticker.FixedFormatter(['Good', 'High Noise', 'High Dark']))
+            plt.colorbar(orientation='horizontal', label='Bad pixel type', ticks=np.arange(nr_types+1)+0.5,
+                         format=mticker.FixedFormatter(bad_pixel_labels[:len(nr_types)+1]))
             
             # Get combined numbers and percentages of bad pixels
             summary_text = ''


### PR DESCRIPTION
A full revamp of the bad pixel identification and mapping. 

I realised that we are really dealing with two different definitions of 'bad' pixels, both of which we want to track:
- Pixels that are anomalously bad/not working properly that we want to exclude from calculations 
- Pixels that are working fine but do not meet the L3/L4 requirements for the UVEX detectors (so we still want to include them in measurements, but also want to tabulate how much of the detector does not meet requirements)

I've designated these bad pixel types as non-working (nw) and not-meeting-requirements (nr) respectively in the code and output, though if anyone has ideas for better terminology, let me know. Non-working definitions are taken from the thresholds listed in Issue #22 and the requirements definitions are currently tied to the FUV imager read noise and dark current L3 requirements (so far there are no linearity/Q.E. requirements but they may appear at L4?)

Output now contains a bad pixel map for both types of bad pixel, and the non-working pixels only are masked when calculating the final values for the gain, read noise, and dark current. FITS images of the bad pixel maps are saved in the output folder. The report also now shows the exposure time ratio frames, since this is used to determine bad linearity pixels anyway. 

I've attached a PDF of the current version of the report using one of the old February data sets: [20250220_cmost_DIE103_analysis_report_20250813135949.pdf](https://github.com/user-attachments/files/21762804/20250220_cmost_DIE103_analysis_report_20250813135949.pdf) (Note that while the dark current issues at the time mean that none of the pixels meet requirements, there are relatively few actually bad i.e. non-working pixels)

One improvement to the overall output summary would be to explicitly indicate whether the detector passes/fails under the NUV and FUV versions of the L3 requirements and the various thresholds within.

Also in this update:
- Bias frames have been renamed in outputs to 'pixel offset' frames as per terminology discussion on 08/11
- Default temperature is now listed as 180K

Closes #22 (for now). 